### PR TITLE
Implementation based on Zabbix Go code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,55 +1,11 @@
-# Prerequisites
-*.d
-
 # Object files
 *.o
-*.ko
-*.obj
-*.elf
-
-# Linker output
-*.ilk
-*.map
-*.exp
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Libraries
-*.lib
-*.a
-*.la
-*.lo
 
 # Shared objects (inc. Windows DLLs)
 *.dll
 *.so
 *.so.*
 *.dylib
-
-# Executables
-*.exe
-*.out
-*.app
-*.i*86
-*.x86_64
-*.hex
-
-# Debug files
-*.dSYM/
-*.su
-*.idb
-*.pdb
-
-# Kernel Module Compile Results
-*.mod*
-*.cmd
-.tmp_versions/
-modules.order
-Module.symvers
-Mkfile.old
-dkms.conf
 
 # Compilations database
 compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ tests/__pycache__/
 
 # Pytest
 .pytest_cache/
+
+# CGO
+sheepskin-cgo.h

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -7,10 +7,10 @@ RUN sudo apt-get -q update && \
         autoconf \
         automake \
         bear \
-        libcurl4-openssl-dev \
         python3-pytest \
     && \
     sudo rm -rf /var/lib/apt/lists/*
 
 ENV ZABBIX_SOURCE=/workspace/zabbix
 ENV PATH=/workspace/sbin:/workspace/bin:$PATH
+ENV LD_LIBRARY_PATH=/workspace/sheepskin

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 - ./configure
 - cd -
 script:
-- ZABBIX_SOURCE=zabbix CFLAGS='-Wall -Wextra -Wpedantic -g -O2' make
+- ZABBIX_SOURCE=$PWD/zabbix CFLAGS='-Wall -Wextra -Wpedantic -g -O2' make
 - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
 - docker-compose --file tests/docker-compose.yml up --detach
 - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ env:
 services:
 - docker
 before_install:
-- sudo apt update
-- sudo apt install libcurl4-openssl-dev
 - pip install pytest
 before_script:
 - git clone https://git.zabbix.com/scm/zbx/zabbix.git --depth 1 --single-branch --branch $BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: c
 compiler:
 - clang
 - gcc
+go:
+- "1.13"
 dist: focal
 env:
 - BRANCH=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: go
 compiler:
 - clang
 - gcc

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 CFLAGS:=-fPIC -I$(ZABBIX_SOURCE)/include $(CFLAGS)
 OBJECTS:=$(patsubst %.c,%.o,$(wildcard src/*.c))
 
-.PHONY: all clean
+.PHONY: all clean sheepskin-cgo.so
 
-all: sheepskin.so
+all: sheepskin.so sheepskin-cgo.so
 
 sheepskin.so: $(OBJECTS)
-	$(CC) $(OBJECTS) $(LDFLAGS) $(LIBS) `curl-config --libs` -shared -o $@
+	$(CC) $(OBJECTS) $(LDFLAGS) $(LIBS) -ldl -shared -o $@
+
+sheepskin-cgo.so:
+	CGO_CFLAGS="-I$(ZABBIX_SOURCE)/include $(CFLAGS) -Wno-unused-parameter" go build -o $@ -buildmode c-shared
 
 clean:
-	rm -rf $(OBJECTS) sheepskin.so
+	rm -rf $(OBJECTS) sheepskin.so sheepskin-cgo.*

--- a/README.md
+++ b/README.md
@@ -5,3 +5,91 @@
 for monitoring
 website
 [certificates](https://en.wikipedia.org/wiki/Public_key_certificate)
+
+## summary
+
+This module provides
+[Zabbix agent 2 feature of monitoring certificates](https://support.zabbix.com/browse/ZBXNEXT-6708)
+in the form compatible with Zabbix server / proxy
+[as was originally requested](https://support.zabbix.com/browse/ZBXNEXT-5931).
+Agent (the "old" one) is supported too.
+
+Module uses some of Zabbix code completely unchanged,
+so the behaviour should be identical to native `web.certificate.get` item and
+[templates designed for agent 2](https://git.zabbix.com/projects/ZBX/repos/zabbix/browse/templates/app/certificate_agent2)
+should require only minor modifications.
+
+## compile
+
+You will need an environment with working
+[C](https://en.wikipedia.org/wiki/List_of_compilers#C_compilers)
+and
+[Go](https://golang.org/doc/install)
+compilers.
+
+1. [Download](https://www.zabbix.com/download_sources)
+Zabbix source or check it out from
+[Git repository](https://git.zabbix.com/):
+```bash
+git clone https://git.zabbix.com/scm/zbx/zabbix.git --depth 1 /path/to/zabbix/source
+```
+Note that you need to compile module using sources of the version you will be using it with!
+
+2. Configure Zabbix sources:
+```bash
+cd /path/to/zabbix/source
+./bootstrap.sh
+./configure
+```
+
+3. Get module sources,
+point them to Zabbix source directory
+and run `make` to build,
+it should produce `sheepskin.so` and `sheepskin-cgo.so` shared libraries.
+```bash
+cd /path/to/sheepskin/source
+export ZABBIX_SOURCE=/path/to/zabbix/source
+make
+```
+
+## install
+
+Copy `sheepskin.so` and `sheepskin-cgo.so` to a desired location, set up necessary permissions.
+
+## configure
+
+Set `LoadModulePath` and `LoadModule` parameters in Zabbix
+[agent](https://www.zabbix.com/documentation/current/manual/appendix/config/zabbix_agentd) /
+[proxy](https://www.zabbix.com/documentation/current/manual/appendix/config/zabbix_proxy) /
+[server](https://www.zabbix.com/documentation/current/manual/appendix/config/zabbix_server)
+configuration file.
+```
+LoadModulePath=/path/to/modules/
+LoadModule=sheepskin.so
+```
+or
+```
+LoadModulePath=/path/to/modules/sheepskin.so
+```
+Restart Zabbix agent / proxy / server.
+
+Note that you _don't need_ to mention `sheepskin-cgo.so` in Zabbix configuration file.
+It will be loaded in runtime using `dlopen("sheepskin-cgo.so", ...)`.
+
+Please make sure that
+[`dlopen()` can find](https://man7.org/linux/man-pages/man3/dlopen.3.html)
+`sheepskin-cgo.so` (e.g. by setting `LD_LIBRARY_PATH` appropriately).
+
+## use
+
+Configure `web.certificate.get` checks:
+* use item type
+[_Simple check_](https://www.zabbix.com/documentation/current/manual/config/items/itemtypes/simple_checks)
+if the module is loaded by server or proxy;
+* use item type
+[_Zabbix agent_ or _Zabbix agent (active)_](https://www.zabbix.com/documentation/current/manual/config/items/itemtypes/zabbix_agent)
+if the module is loaded by agent.
+
+Please refer to
+[official documentation of `web.certificate.get`](https://www.zabbix.com/documentation/current/manual/config/items/itemtypes/zabbix_agent/zabbix_agent2?s%5B%5D=web.certificate.get)
+for further details.

--- a/g2z.c
+++ b/g2z.c
@@ -1,0 +1,21 @@
+#include "module.h"
+
+int	sheep_get_rparams_num(const AGENT_REQUEST *request)
+{
+	return get_rparams_num(request);
+}
+
+const char	*sheep_get_rparam(const AGENT_REQUEST *request, int num)
+{
+	return get_rparam(request, num);
+}
+
+void	sheep_SET_TEXT_RESULT(AGENT_RESULT *res, const char *val)
+{
+	SET_TEXT_RESULT(res, val);
+}
+
+void	sheep_SET_MSG_RESULT(AGENT_RESULT *res, const char *val)
+{
+	SET_MSG_RESULT(res, val);
+}

--- a/g2z.c
+++ b/g2z.c
@@ -1,4 +1,4 @@
-#include "module.h"
+#include "g2z.h"
 
 int	sheep_get_rparams_num(const AGENT_REQUEST *request)
 {

--- a/g2z.go
+++ b/g2z.go
@@ -1,0 +1,41 @@
+package main
+
+/*
+#include "g2z.h"
+*/
+import "C"
+
+import (
+	"zabbix.com/pkg/plugin"
+	webcertificate "zabbix.com/plugins/web/certificate"
+)
+
+var impl webcertificate.Plugin
+
+//export sheep_set_timeout
+func sheep_set_timeout(timeout C.int) {
+	var options plugin.GlobalOptions
+	options.Timeout = int(timeout)
+	impl.Configure(&options, nil)
+}
+
+//export sheep_check_item
+func sheep_check_item(request *C.AGENT_REQUEST, result *C.AGENT_RESULT) C.int {
+	var params = make([]string, C.sheep_get_rparams_num(request))
+
+	for i := 0; i < len(params); i++ {
+		params[i] = C.GoString(C.sheep_get_rparam(request, C.int(i)))
+	}
+
+	if text, err := impl.Export("web.certificate.get", params, nil); err != nil {
+		C.sheep_SET_MSG_RESULT(result, C.CString(err.Error()))
+		return C.SYSINFO_RET_FAIL
+	} else {
+		C.sheep_SET_TEXT_RESULT(result, C.CString(text.(string)))
+		return C.SYSINFO_RET_OK
+	}
+}
+
+func main() {
+	panic("This should never happen.")
+}

--- a/g2z.h
+++ b/g2z.h
@@ -1,3 +1,6 @@
+#include <stdint.h>
+#include <stdlib.h>
+
 #include "module.h"
 
 int		sheep_get_rparams_num(const AGENT_REQUEST *request);

--- a/g2z.h
+++ b/g2z.h
@@ -1,0 +1,6 @@
+#include "module.h"
+
+int		sheep_get_rparams_num(const AGENT_REQUEST *request);
+const char	*sheep_get_rparam(const AGENT_REQUEST *request, int num);
+void		sheep_SET_TEXT_RESULT(AGENT_RESULT *res, const char *val);
+void		sheep_SET_MSG_RESULT(AGENT_RESULT *res, const char *val);

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module zabbix.com
 
-go 1.16
+go 1.13
 
-require golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf
+require golang.org/x/sys v0.0.0-20210104204734-6f8348627aad

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module zabbix.com
+
+go 1.16
+
+require golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf h1:2ucpDCmfkl8Bd/FsLtiD653Wf96cW37s+iGx93zsu4k=
+golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf h1:2ucpDCmfkl8Bd/FsLtiD653Wf96cW37s+iGx93zsu4k=
-golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210104204734-6f8348627aad h1:MCsdmFSdEd4UEa5TKS5JztCRHK/WtvNei1edOj5RSRo=
+golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -1,0 +1,580 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+// Package conf provides .conf file loading and unmarshalling
+package conf
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"zabbix.com/pkg/std"
+)
+
+// Meta structure is used to store the 'conf' tag metadata.
+type Meta struct {
+	name         string
+	defaultValue *string
+	optional     bool
+	min          int64
+	max          int64
+}
+type Suffix struct {
+	suffix string
+	factor int
+}
+
+func validateParameterName(key []byte) (err error) {
+	for i, b := range key {
+		if ('A' > b || b > 'Z') && ('a' > b || b > 'z') && ('0' > b || b > '9') && b != '_' && b != '.' {
+			return fmt.Errorf("invalid character '%c' at position %d", b, i+1)
+		}
+	}
+	return
+}
+
+// parseLine parses parameter configuration line and returns key,value pair.
+// The line must have format: <key>[ ]=[ ]<value> where whitespace surrounding
+// '=' is optional.
+func parseLine(line []byte) (key []byte, value []byte, err error) {
+	valueStart := bytes.IndexByte(line, '=')
+	if valueStart == -1 {
+		return nil, nil, errors.New("missing assignment operator")
+	}
+
+	if key = bytes.TrimSpace(line[:valueStart]); len(key) == 0 {
+		return nil, nil, errors.New("missing variable name")
+	}
+
+	if err = validateParameterName(key); err != nil {
+		return
+	}
+
+	return key, bytes.TrimSpace(line[valueStart+1:]), nil
+}
+
+// getMeta returns 'conf' tag metadata.
+// The metadata has format [name=<name>,][optional,][range=<range>,][default=<default value>]
+//   where:
+//   <name> - the parameter name,
+//   optional - set if the value is optional,
+//   <range> - the allowed range <min>:<max>, where <min>, <max> values are optional,
+//   <default value> - the default value. If specified it must always be the last tag.
+func getMeta(field reflect.StructField) (meta *Meta, err error) {
+	m := Meta{name: "", optional: false, min: -1, max: -1}
+	conf := field.Tag.Get("conf")
+
+loop:
+	for conf != "" {
+		tags := strings.SplitN(conf, ",", 2)
+		fields := strings.SplitN(tags[0], "=", 2)
+		tag := strings.TrimSpace(fields[0])
+		if len(fields) == 1 {
+			// boolean tag
+			switch tag {
+			case "optional":
+				m.optional = true
+			default:
+				return nil, fmt.Errorf("invalid conf tag '%s'", tag)
+			}
+		} else {
+			// value tag
+			switch tag {
+			case "default":
+				value := fields[1]
+				if len(tags) == 2 {
+					value += "," + tags[1]
+				}
+				m.defaultValue = &value
+				break loop
+			case "name":
+				m.name = strings.TrimSpace(fields[1])
+			case "range":
+				limits := strings.Split(fields[1], ":")
+				if len(limits) != 2 {
+					return nil, errors.New("invalid range format")
+				}
+				if limits[0] != "" {
+					m.min, _ = strconv.ParseInt(limits[0], 10, 64)
+				}
+				if limits[1] != "" {
+					m.max, _ = strconv.ParseInt(limits[1], 10, 64)
+				}
+			default:
+				return nil, fmt.Errorf("invalid conf tag '%s'", tag)
+			}
+		}
+
+		if len(tags) == 1 {
+			break
+		}
+		conf = tags[1]
+	}
+
+	if m.name == "" {
+		m.name = field.Name
+	}
+	return &m, nil
+}
+
+func getTimeSuffix(str string) (string, int) {
+	suffixes := []Suffix{
+		Suffix{
+			suffix: "s",
+			factor: 1,
+		},
+		Suffix{
+			suffix: "m",
+			factor: 60,
+		},
+		Suffix{
+			suffix: "h",
+			factor: 3600,
+		},
+		Suffix{
+			suffix: "d",
+			factor: 86400,
+		},
+		Suffix{
+			suffix: "w",
+			factor: (7 * 86400),
+		},
+	}
+
+	for _, s := range suffixes {
+		if strings.HasSuffix(str, s.suffix) == true {
+			str = strings.TrimSuffix(str, s.suffix)
+			return str, s.factor
+		}
+	}
+	return str, 1
+
+}
+
+func setBasicValue(value reflect.Value, meta *Meta, str *string) (err error) {
+	if str == nil {
+		return nil
+	}
+	switch value.Type().Kind() {
+	case reflect.String:
+		value.SetString(*str)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		var v int64
+		var r int
+		*str, r = getTimeSuffix(*str)
+		if v, err = strconv.ParseInt(*str, 10, 64); err == nil {
+			v = v * int64(r)
+			if meta != nil {
+				if meta.min != -1 && v < meta.min || meta.max != -1 && v > meta.max {
+					return errors.New("value out of range")
+				}
+			}
+			value.SetInt(v)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		var v uint64
+		var r int
+		*str, r = getTimeSuffix(*str)
+		if v, err = strconv.ParseUint(*str, 10, 64); err == nil {
+			v = v * uint64(r)
+			if meta != nil {
+				if meta.min != -1 && v < uint64(meta.min) || meta.max != -1 && v > uint64(meta.max) {
+					return errors.New("value out of range")
+				}
+			}
+			value.SetUint(v)
+		}
+	case reflect.Float32, reflect.Float64:
+		var v float64
+		if v, err = strconv.ParseFloat(*str, 64); err == nil {
+			if meta != nil {
+				if meta.min != -1 && v < float64(meta.min) || meta.max != -1 && v > float64(meta.max) {
+					return errors.New("value out of range")
+				}
+			}
+			value.SetFloat(v)
+		}
+	case reflect.Bool:
+		var v bool
+		switch *str {
+		case "true":
+			v = true
+		case "false":
+			v = false
+		default:
+			return errors.New("invalid boolean value")
+		}
+		value.SetBool(v)
+	case reflect.Ptr:
+		v := reflect.New(value.Type().Elem())
+		value.Set(v)
+		return setBasicValue(v.Elem(), meta, str)
+	default:
+		err = fmt.Errorf("unsupported variable type %v", value.Type().Kind())
+	}
+	return err
+}
+
+func setStructValue(value reflect.Value, node *Node) (err error) {
+	rt := value.Type()
+	for i := 0; i < rt.NumField(); i++ {
+		var meta *Meta
+		if meta, err = getMeta(rt.Field(i)); err != nil {
+			return
+		}
+		child := node.get(meta.name)
+		if child != nil || meta.defaultValue != nil {
+			if err = setValue(value.Field(i), meta, child); err != nil {
+				return
+			}
+		} else if !meta.optional {
+			return fmt.Errorf("cannot find mandatory parameter %s", meta.name)
+		}
+	}
+	return
+}
+
+func setMapValue(value reflect.Value, node *Node) (err error) {
+	m := reflect.MakeMap(reflect.MapOf(value.Type().Key(), value.Type().Elem()))
+	for _, v := range node.Nodes {
+		if child, ok := v.(*Node); ok {
+			k := reflect.New(value.Type().Key())
+			if err = setBasicValue(k.Elem(), nil, &child.Name); err != nil {
+				return
+			}
+			v := reflect.New(value.Type().Elem())
+			if err = setValue(v.Elem(), nil, child); err != nil {
+				return
+			}
+			m.SetMapIndex(k.Elem(), v.Elem())
+		}
+	}
+	value.Set(m)
+	return
+}
+
+func setSliceValue(value reflect.Value, node *Node) (err error) {
+	tmpValues := make([][]byte, 0)
+	for _, v := range node.Nodes {
+		if val, ok := v.(*Value); ok {
+			tmpValues = append(tmpValues, val.Value)
+		}
+	}
+	size := len(tmpValues)
+	values := reflect.MakeSlice(reflect.SliceOf(value.Type().Elem()), 0, size)
+
+	if len(tmpValues) > 0 {
+		for _, data := range tmpValues {
+			v := reflect.New(value.Type().Elem())
+			str := string(data)
+			if err = setBasicValue(v.Elem(), nil, &str); err != nil {
+				return
+			}
+			values = reflect.Append(values, v.Elem())
+		}
+	} else {
+		for _, n := range node.Nodes {
+			if child, ok := n.(*Node); ok {
+				v := reflect.New(value.Type().Elem())
+				if err = setValue(v.Elem(), nil, child); err != nil {
+					return
+				}
+				values = reflect.Append(values, v.Elem())
+			}
+		}
+	}
+	value.Set(values)
+	return
+}
+
+func setValue(value reflect.Value, meta *Meta, node *Node) (err error) {
+	var str *string
+	if node != nil {
+		node.used = true
+	}
+	switch value.Type().Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64, reflect.Bool, reflect.String:
+		if str, err = node.getValue(meta); err == nil {
+			if err = setBasicValue(value, meta, str); err != nil {
+				return node.newError("%s", err.Error())
+			}
+		}
+	case reflect.Struct:
+		if node != nil {
+			return setStructValue(value, node)
+		}
+	case reflect.Map:
+		if node != nil {
+			return setMapValue(value, node)
+		}
+	case reflect.Slice:
+		if node != nil {
+			return setSliceValue(value, node)
+		}
+	case reflect.Ptr:
+		v := reflect.New(value.Type().Elem())
+		value.Set(v)
+		return setValue(v.Elem(), meta, node)
+	case reflect.Interface:
+		value.Set(reflect.ValueOf(node))
+		node.markUsed(true)
+	}
+
+	return nil
+}
+
+// assignValues assigns parsed nodes to the specified structure
+func assignValues(v interface{}, root *Node) (err error) {
+	rv := reflect.ValueOf(v)
+
+	switch rv.Type().Kind() {
+	case reflect.Ptr:
+		rv = rv.Elem()
+	default:
+		return errors.New("output variable must be a pointer to a structure")
+	}
+
+	switch rv.Type().Kind() {
+	case reflect.Struct:
+		if err = setStructValue(rv, root); err != nil {
+			return err
+		}
+	default:
+		return errors.New("output variable must be a pointer to a structure")
+	}
+	return root.checkUsage()
+}
+
+func newIncludeError(root *Node, filename *string, errmsg string) (err error) {
+	if root.includeFail {
+		return errors.New(errmsg)
+	}
+	root.includeFail = true
+	if filename != nil {
+		return fmt.Errorf(`cannot include "%s": %s`, *filename, errmsg)
+	}
+	return fmt.Errorf(`cannot load file: %s`, errmsg)
+}
+
+func hasMeta(path string) bool {
+	var metaChars string
+	if runtime.GOOS != "windows" {
+		metaChars = `*?[\`
+	} else {
+		metaChars = `*?[`
+	}
+	return strings.ContainsAny(path, metaChars)
+}
+
+func loadInclude(root *Node, path string) (err error) {
+	if hasMeta(filepath.Dir(path)) {
+		return newIncludeError(root, &path, "glob pattern is supported only in file names")
+	}
+	if !hasMeta(path) {
+		var fi os.FileInfo
+		if fi, err = stdOs.Stat(path); err != nil {
+			return newIncludeError(root, &path, err.Error())
+		}
+		if fi.IsDir() {
+			path = filepath.Join(path, "*")
+		}
+	} else {
+		var fi os.FileInfo
+		if fi, err = stdOs.Stat(filepath.Dir(path)); err != nil {
+			return newIncludeError(root, &path, err.Error())
+		}
+		if !fi.IsDir() {
+			return newIncludeError(root, &path, "base path is not a directory")
+		}
+	}
+
+	var paths []string
+	if hasMeta(path) {
+		if paths, err = filepath.Glob(path); err != nil {
+			return newIncludeError(root, nil, err.Error())
+		}
+	} else {
+		paths = append(paths, path)
+	}
+
+	for _, path := range paths {
+		// skip directories
+		var fi os.FileInfo
+		if fi, err = stdOs.Stat(path); err != nil {
+			return newIncludeError(root, &path, err.Error())
+		}
+		if fi.IsDir() {
+			continue
+		}
+		if !filepath.IsAbs(path) {
+			return newIncludeError(root, &path, "relative paths are not supported")
+		}
+
+		var file std.File
+		if file, err = stdOs.Open(path); err != nil {
+			return newIncludeError(root, &path, err.Error())
+		}
+		defer file.Close()
+
+		buf := bytes.Buffer{}
+		if _, err = buf.ReadFrom(file); err != nil {
+			return newIncludeError(root, &path, err.Error())
+		}
+
+		if err = parseConfig(root, buf.Bytes()); err != nil {
+			return newIncludeError(root, &path, err.Error())
+		}
+	}
+	return
+}
+
+func parseConfig(root *Node, data []byte) (err error) {
+	const maxStringLen = 2048
+	var line []byte
+
+	root.level++
+
+	for offset, end, num := 0, 0, 1; end != -1; offset, num = offset+end+1, num+1 {
+		if end = bytes.IndexByte(data[offset:], '\n'); end != -1 {
+			line = bytes.TrimSpace(data[offset : offset+end])
+		} else {
+			line = bytes.TrimSpace(data[offset:])
+		}
+
+		if len(line) > maxStringLen {
+			return fmt.Errorf("cannot parse configuration at line %d: limit of %d bytes is exceeded", num, maxStringLen)
+		}
+
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+
+		if !utf8.ValidString(string(line)) {
+			return fmt.Errorf("cannot parse configuration at line %d: not a valid UTF-8 character found", num)
+		}
+
+		var key, value []byte
+		if key, value, err = parseLine(line); err != nil {
+			return fmt.Errorf("cannot parse configuration at line %d: %s", num, err.Error())
+		}
+		if string(key) == "Include" {
+			if root.level == 10 {
+				return fmt.Errorf("include depth exceeded limits")
+			}
+
+			if err = loadInclude(root, string(value)); err != nil {
+				return
+			}
+		} else {
+			root.add(key, value, num)
+		}
+	}
+	root.level--
+	return nil
+}
+
+// Unmarshal unmarshals input data into specified structure. The input data can be either
+// a byte array ([]byte) with configuration file or interface{} either returned by Marshal
+// or a configuration file Unmarshaled into interface{} variable before.
+// The third is optional 'strict' parameter that forces strict validation of configuration
+// and structure fields (enabled by default). When disabled it will unmarshal part of
+// configuration into incomplete target structures.
+func Unmarshal(data interface{}, v interface{}, args ...interface{}) (err error) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("Invalid output parameter")
+	}
+
+	strict := true
+	if len(args) > 0 {
+		var ok bool
+		if strict, ok = args[0].(bool); !ok {
+			return errors.New("Invalid mode parameter")
+		}
+	}
+
+	var root *Node
+	switch u := data.(type) {
+	case nil:
+		root = &Node{
+			Name:   "",
+			used:   false,
+			Nodes:  make([]interface{}, 0),
+			parent: nil,
+			Line:   0}
+	case []byte:
+		root = &Node{
+			Name:   "",
+			used:   false,
+			Nodes:  make([]interface{}, 0),
+			parent: nil,
+			Line:   0}
+
+		if err = parseConfig(root, u); err != nil {
+			return fmt.Errorf("Cannot read configuration: %s", err.Error())
+		}
+	case *Node:
+		root = u
+		root.markUsed(false)
+	default:
+		return errors.New("Invalid input parameter")
+	}
+
+	if !strict {
+		root.markUsed(true)
+	}
+
+	if err = assignValues(v, root); err != nil {
+		return fmt.Errorf("Cannot assign configuration: %s", err.Error())
+	}
+
+	return nil
+}
+
+func Load(filename string, v interface{}) (err error) {
+	var file std.File
+
+	if file, err = stdOs.Open(filename); err != nil {
+		return fmt.Errorf(`cannot open configuration file: %s`, err.Error())
+	}
+	defer file.Close()
+
+	buf := bytes.Buffer{}
+	if _, err = buf.ReadFrom(file); err != nil {
+		return fmt.Errorf("cannot load configuration: %s", err.Error())
+	}
+
+	return Unmarshal(buf.Bytes(), v)
+}
+
+var stdOs std.Os
+
+func init() {
+	stdOs = std.NewOs()
+}

--- a/pkg/conf/node.go
+++ b/pkg/conf/node.go
@@ -1,0 +1,152 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+// Package conf provides .conf file loading and unmarshalling
+package conf
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Node structure is used to store parsed conf file parameters or parameter components.
+type Node struct {
+	Name  string
+	Nodes []interface{}
+	Line  int
+
+	used        bool
+	parent      *Node
+	level       int
+	includeFail bool
+}
+
+type Value struct {
+	Value []byte
+	Line  int
+}
+
+// get returns child node by name
+func (n *Node) get(name string) (node *Node) {
+	for _, v := range n.Nodes {
+		if child, ok := v.(*Node); ok && child.Name == name {
+			return child
+		}
+	}
+	return nil
+}
+
+// add appends new child node
+func (n *Node) add(name []byte, value []byte, lineNum int) {
+	var node *Node
+	var key string
+
+	split := bytes.IndexByte(name, '.')
+	if split == -1 {
+		key = string(name)
+	} else {
+		key = string(name[:split])
+	}
+
+	if node = n.get(key); node == nil {
+		node = &Node{
+			Name:   string(key),
+			used:   false,
+			Nodes:  make([]interface{}, 0),
+			parent: n,
+			Line:   lineNum}
+		n.Nodes = append(n.Nodes, node)
+	}
+
+	if split != -1 {
+		node.add(name[split+1:], value, lineNum)
+	} else {
+		node.Nodes = append(node.Nodes, &Value{Value: value, Line: lineNum})
+	}
+}
+
+// checkUsage checks if all conf nodes were recognized.
+// This is done by recursively checking 'used' flag for all nodes.
+func (n *Node) checkUsage() (err error) {
+	for _, v := range n.Nodes {
+		if child, ok := v.(*Node); ok {
+			if !child.used {
+				return child.newError("unknown parameter")
+			}
+			if err = child.checkUsage(); err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// markUsed marks node and its children as used
+func (n *Node) markUsed(used bool) {
+	n.used = used
+	for _, v := range n.Nodes {
+		if child, ok := v.(*Node); ok {
+			child.markUsed(used)
+		}
+	}
+}
+
+// getValue returns node value or meta data default value or nil if
+// metadata 'optional' tag is set. Otherwise error is returned.
+func (n *Node) getValue(meta *Meta) (value *string, err error) {
+	if n != nil {
+		var tmp string
+		for _, v := range n.Nodes {
+			if val, ok := v.(*Value); ok {
+				tmp = string(val.Value)
+			}
+			value = &tmp
+		}
+	}
+
+	if value == nil && meta != nil {
+		if meta.defaultValue != nil {
+			value = meta.defaultValue
+		} else if meta.optional {
+			return
+		} else {
+			return nil, fmt.Errorf("cannot find mandatory parameter %s", meta.name)
+		}
+	}
+	return
+}
+
+// newNodeError creates error based on the specified node. The error message will
+// have full node name (parameter name up to the node, including it) and the line
+// number where parameter was defined.
+func (n *Node) newError(format string, a ...interface{}) (err error) {
+	if n == nil {
+		return fmt.Errorf(format, a...)
+	}
+	var name string
+	for parent := n; parent.parent != nil; parent = parent.parent {
+		if name == "" {
+			name = parent.Name
+		} else {
+			name = parent.Name + "." + name
+		}
+	}
+	desc := fmt.Sprintf(format, a...)
+	return fmt.Errorf("invalid parameter %s at line %d: %s", name, n.Line, desc)
+}

--- a/pkg/conf/session.go
+++ b/pkg/conf/session.go
@@ -1,0 +1,28 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+// Package conf provides .conf file loading and unmarshalling
+package conf
+
+// Session is a general structure for storing sessions' configuration.
+type Session struct {
+	URI      string `conf:"name=Uri,optional"`
+	Password string `conf:"optional"`
+	User     string `conf:"optional"`
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,270 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+package log
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"sync"
+)
+
+const Info = 0
+const Crit = 1
+const Err = 2
+const Warning = 3
+const Debug = 4
+const Trace = 5
+
+const None = -1
+
+const Undefined = 0
+const System = 1
+const File = 2
+const Console = 3
+
+const MB = 1048576
+
+//DefaultLogger is the default Zabbix agent 2 and Zabbix web service logger.
+var DefaultLogger *log.Logger
+
+var logLevel int
+
+type LogStat struct {
+	logType     int
+	filename    string
+	filesize    int64
+	f           *os.File
+	currentSize int64
+}
+
+var logStat LogStat
+var logAccess sync.Mutex
+
+func CheckLogLevel(level int) bool {
+	if level > logLevel {
+		return false
+	}
+	return true
+}
+
+func Level() string {
+	switch logLevel {
+	case None:
+		return "none"
+	case Info:
+		return "info"
+	case Crit:
+		return "critical"
+	case Err:
+		return "error"
+	case Warning:
+		return "warning"
+	case Debug:
+		return "debug"
+	case Trace:
+		return "trace"
+	default:
+		return "unknown"
+	}
+}
+
+func IncreaseLogLevel() (success bool) {
+	if logLevel != Trace {
+		logLevel++
+		return true
+	}
+	return false
+}
+
+func DecreaseLogLevel() (success bool) {
+	if logLevel != Info {
+		logLevel--
+		return true
+	}
+	return false
+}
+
+// Open sets a new logger based on the log type and a new log output level
+func Open(logType int, level int, filename string, filesize int) error {
+	logStat.logType = logType
+	logStat.filename = filename
+	logStat.filesize = int64(filesize) * MB
+	var err error
+
+	switch logType {
+	case System:
+		err = createSyslog()
+		if err != nil {
+			return err
+		}
+	case Console:
+		DefaultLogger = log.New(os.Stdout, "", log.Lmicroseconds|log.Ldate)
+	case File:
+		logStat.f, err = os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return err
+		}
+		DefaultLogger = log.New(logStat.f, "", log.Lmicroseconds|log.Ldate)
+	default:
+		return errors.New("invalid argument")
+	}
+
+	logLevel = level
+	return nil
+}
+
+func Infof(format string, args ...interface{}) {
+	if CheckLogLevel(Info) {
+		procLog(format, args, Info)
+	}
+}
+
+func Critf(format string, args ...interface{}) {
+	if CheckLogLevel(Crit) {
+		procLog(format, args, Crit)
+	}
+}
+
+func Errf(format string, args ...interface{}) {
+	if CheckLogLevel(Err) {
+		procLog(format, args, Err)
+	}
+}
+
+func Warningf(format string, args ...interface{}) {
+	if CheckLogLevel(Warning) {
+		procLog(format, args, Warning)
+	}
+}
+
+func Tracef(format string, args ...interface{}) {
+	if CheckLogLevel(Trace) {
+		procLog(format, args, Trace)
+	}
+}
+
+func Debugf(format string, args ...interface{}) {
+	if CheckLogLevel(Debug) {
+		procLog(format, args, Debug)
+	}
+}
+
+func procLog(format string, args []interface{}, level int) {
+	if logStat.logType == System {
+		procSysLog(format, args, level)
+		return
+	}
+
+	logAccess.Lock()
+	defer logAccess.Unlock()
+	rotateLog()
+	DefaultLogger.Printf(format, args...)
+}
+
+func rotateLog() {
+	if logStat.logType == File {
+		fstat, err := os.Stat(logStat.filename)
+		if err != nil || fstat.Size() == 0 || logStat.currentSize > fstat.Size() {
+
+			logStat.f.Close()
+
+			if logStat.f, err = os.OpenFile(logStat.filename, os.O_CREATE|os.O_WRONLY, 0644); err != nil {
+				logStat.logType = Undefined
+				log.Fatal(fmt.Sprintf("Cannot open log file %s", logStat.filename))
+			}
+
+			DefaultLogger = log.New(logStat.f, "", log.Lmicroseconds|log.Ldate)
+			logStat.currentSize = 0
+			return
+		}
+
+		if logStat.filesize != 0 {
+			var printError string
+
+			logStat.currentSize = fstat.Size()
+
+			if logStat.currentSize > logStat.filesize {
+				filenameOld := logStat.filename + ".old"
+				logStat.f.Close()
+				os.Remove(filenameOld)
+
+				err = os.Rename(logStat.filename, filenameOld)
+				if err != nil {
+					printError = err.Error()
+				}
+
+				logStat.f, err = os.OpenFile(logStat.filename, os.O_CREATE|os.O_WRONLY, 0644)
+				if err != nil {
+					errmsg := fmt.Sprintf("Cannot open log file %s", logStat.filename)
+					if printError != "" {
+						errmsg = fmt.Sprintf("%s and cannot rename it: %s", errmsg, printError)
+					}
+					logStat.logType = Undefined
+					log.Fatal(errmsg)
+				}
+
+				DefaultLogger = log.New(logStat.f, "", log.Lmicroseconds|log.Ldate)
+				if printError != "" {
+					DefaultLogger.Printf("cannot rename log file \"%s\" to \"%s\":%s\n",
+						logStat.filename, filenameOld, printError)
+					DefaultLogger.Printf("Logfile \"%s\" size reached configured limit LogFileSize but"+
+						" moving it to \"%s\" failed. The logfile was truncated.",
+						logStat.filename, filenameOld)
+				}
+			}
+		}
+	}
+}
+
+func PanicHook() {
+	if r := recover(); r != nil {
+		if logStat.logType != Undefined {
+			data := debug.Stack()
+			Critf("Critical failure: %v", r)
+			var tail int
+			for offset, end, num := 0, 0, 1; end != -1; offset, num = offset+end+1, num+1 {
+				end = bytes.IndexByte(data[offset:], '\n')
+				if end != -1 {
+					tail = offset + end
+				} else {
+					tail = len(data)
+				}
+				Critf("%s", string(data[offset:tail]))
+			}
+		}
+		panic(r)
+	}
+}
+
+func Caller() (name string) {
+	pc := make([]uintptr, 2)
+	n := runtime.Callers(2, pc)
+	frames := runtime.CallersFrames(pc[:n])
+	if frame, ok := frames.Next(); ok {
+		return filepath.Base(frame.Func.Name())
+	}
+	return ""
+}

--- a/pkg/log/log_nix.go
+++ b/pkg/log/log_nix.go
@@ -1,0 +1,50 @@
+// +build !windows
+
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+package log
+
+import (
+	"fmt"
+	"log/syslog"
+)
+
+var syslogWriter *syslog.Writer
+
+func createSyslog() (err error) {
+	syslogWriter, err = syslog.New(syslog.LOG_WARNING|syslog.LOG_DAEMON, "zabbix_agent2")
+	return
+}
+
+func procSysLog(format string, args []interface{}, level int) {
+	switch level {
+	case Info:
+		syslogWriter.Info(fmt.Sprintf(format, args...))
+	case Crit:
+		syslogWriter.Crit(fmt.Sprintf(format, args...))
+	case Err:
+		syslogWriter.Err(fmt.Sprintf(format, args...))
+	case Warning:
+		syslogWriter.Warning(fmt.Sprintf(format, args...))
+	case Debug, Trace:
+		syslogWriter.Debug(fmt.Sprintf(format, args...))
+	}
+	return
+}

--- a/pkg/log/log_windows.go
+++ b/pkg/log/log_windows.go
@@ -1,0 +1,32 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+package log
+
+import (
+	"errors"
+)
+
+func createSyslog() error {
+	return errors.New("system log is not supported on Windows")
+}
+
+func procSysLog(format string, args []interface{}, level int) {
+	return
+}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,48 @@
+package log
+
+import "fmt"
+
+type Logger interface {
+	Tracef(format string, args ...interface{})
+	Debugf(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Errf(format string, args ...interface{})
+	Critf(format string, args ...interface{})
+}
+
+type loggerImpl struct {
+	prefix string
+}
+
+func New(module string) Logger {
+	var prefix string
+	if module != "" {
+		prefix = fmt.Sprintf("[%s] ", module)
+	}
+	return &loggerImpl{prefix: prefix}
+}
+
+func (l *loggerImpl) Critf(format string, args ...interface{}) {
+	Critf(l.prefix+format, args...)
+}
+
+func (l *loggerImpl) Infof(format string, args ...interface{}) {
+	Infof(l.prefix+format, args...)
+}
+
+func (l *loggerImpl) Warningf(format string, args ...interface{}) {
+	Warningf(l.prefix+format, args...)
+}
+
+func (l *loggerImpl) Tracef(format string, args ...interface{}) {
+	Tracef(l.prefix+format, args...)
+}
+
+func (l *loggerImpl) Debugf(format string, args ...interface{}) {
+	Debugf(l.prefix+format, args...)
+}
+
+func (l *loggerImpl) Errf(format string, args ...interface{}) {
+	Errf(l.prefix+format, args...)
+}

--- a/pkg/plugin/base.go
+++ b/pkg/plugin/base.go
@@ -1,0 +1,55 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+package plugin
+
+import (
+	"zabbix.com/pkg/log"
+)
+
+type Accessor interface {
+	Init(name string)
+	Name() string
+	Capacity() int
+	SetCapacity(capactity int)
+}
+
+type Base struct {
+	log.Logger
+	name     string
+	capacity int
+}
+
+func (b *Base) Init(name string) {
+	b.Logger = log.New(name)
+	b.name = name
+	b.capacity = DefaultCapacity
+}
+
+func (b *Base) Name() string {
+	return b.name
+}
+
+func (b *Base) Capacity() int {
+	return b.capacity
+}
+
+func (b *Base) SetCapacity(capacity int) {
+	b.capacity = capacity
+}

--- a/pkg/plugin/registry.go
+++ b/pkg/plugin/registry.go
@@ -1,0 +1,125 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+package plugin
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"unicode"
+)
+
+type Metric struct {
+	Plugin      Accessor
+	Key         string
+	Description string
+}
+
+var Metrics map[string]*Metric = make(map[string]*Metric)
+var Plugins map[string]Accessor = make(map[string]Accessor)
+
+func registerMetric(plugin Accessor, name string, key string, description string) {
+	if ok, _ := regexp.MatchString(`^[A-Za-z0-9\._-]+$`, key); !ok {
+		panic(fmt.Sprintf(`cannot register metric "%s" having invalid format`, key))
+	}
+
+	if 0 == len(description) {
+		panic(fmt.Sprintf(`cannot register metric "%s" with empty description`, key))
+	}
+
+	if unicode.IsLower([]rune(description)[0]) {
+		panic(fmt.Sprintf(`cannot register metric "%s" with description without capital first letter: "%s"`, key, description))
+	}
+
+	if description[len(description)-1] != '.' {
+		panic(fmt.Sprintf(`cannot register metric "%s" without dot at the end of description: "%s"`, key, description))
+	}
+
+	if _, ok := Metrics[key]; ok {
+		panic(fmt.Sprintf(`cannot register duplicate metric "%s"`, key))
+	}
+
+	t := reflect.TypeOf(plugin)
+	for i := 0; i < t.NumMethod(); i++ {
+		method := t.Method(i)
+		switch method.Name {
+		case "Export":
+			if _, ok := plugin.(Exporter); !ok {
+				panic(fmt.Sprintf(`the "%s" plugin has %s method, but does implement Exporter interface`, name, method.Name))
+			}
+		case "Collect", "Period":
+			if _, ok := plugin.(Collector); !ok {
+				panic(fmt.Sprintf(`the "%s" plugin has %s method, but does not implement Collector interface`, name, method.Name))
+			}
+		case "Watch":
+			if _, ok := plugin.(Watcher); !ok {
+				panic(fmt.Sprintf(`the "%s" plugin has %s method, but does not implement Watcher interface`, name, method.Name))
+			}
+		case "Configure", "Validate":
+			if _, ok := plugin.(Configurator); !ok {
+				panic(fmt.Sprintf(`the "%s" plugin has %s method, but does not implement Configurator interface`, name, method.Name))
+			}
+		case "Start", "Stop":
+			if _, ok := plugin.(Runner); !ok {
+				panic(fmt.Sprintf(`the "%s" plugin has %s method, but does not implement Runner interface`, name, method.Name))
+			}
+		}
+	}
+	switch plugin.(type) {
+	case Exporter, Collector, Runner, Watcher, Configurator:
+	default:
+		panic(fmt.Sprintf(`plugin "%s" does not implement any plugin interfaces`, name))
+	}
+
+	if p, ok := Plugins[name]; ok {
+		if p != plugin {
+			panic(fmt.Sprintf(`plugin name "%s" has been already registered by other plugin`, name))
+		}
+	} else {
+		Plugins[name] = plugin
+		plugin.Init(name)
+	}
+
+	Metrics[key] = &Metric{Plugin: plugin, Key: key, Description: description}
+}
+
+func RegisterMetrics(impl Accessor, name string, params ...string) {
+	if len(params) < 2 {
+		panic("expected at least one metric and its description")
+	}
+	if len(params)&1 != 0 {
+		panic("expected even number of metric and description parameters")
+	}
+	for i := 0; i < len(params); i += 2 {
+		registerMetric(impl, name, params[i], params[i+1])
+	}
+}
+
+func Get(key string) (acc Accessor, err error) {
+	if m, ok := Metrics[key]; ok {
+		return m.Plugin, nil
+	}
+	return nil, UnsupportedMetricError
+}
+
+func ClearRegistry() {
+	Metrics = make(map[string]*Metric)
+	Plugins = make(map[string]Accessor)
+}

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -1,0 +1,144 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+package plugin
+
+import (
+	"errors"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	DefaultCapacity = 100
+)
+
+var UnsupportedMetricError error
+
+// Collector - interface for periodical metric collection
+type Collector interface {
+	Collect() error
+	Period() int
+}
+
+// Exporter - interface for exporting collected metrics
+type Exporter interface {
+	// Export method exports data based on the key 'key' and its parameters 'params'.
+	Export(key string, params []string, context ContextProvider) (interface{}, error)
+}
+
+// Runner - interface for managing background processes
+type Runner interface {
+	// Start method activates plugin.
+	Start()
+	// Stop method deactivates pluing.
+	Stop()
+}
+
+// Watcher - interface for fully custom monitoring
+type Watcher interface {
+	// Watch method instructs plugin to watch for events based on item configuration in 'requests'.
+	Watch(requests []*Request, context ContextProvider)
+}
+
+// Configurator - interface for plugin configuration in agent conf files
+type Configurator interface {
+	// Configure method passes global and private plugin configuration after it has been activated.
+	Configure(globalOptions *GlobalOptions, privateOptions interface{})
+	// Validate method validates private plugin configuration during agent startup.
+	Validate(privateOptions interface{}) error
+}
+
+type ResultWriter interface {
+	Write(result *Result)
+	Flush()
+	SlotsAvailable() int
+	PersistSlotsAvailable() int
+}
+
+type Meta struct {
+	lastLogsize uint64
+	mtime       int32
+	Data        interface{}
+}
+
+func (m *Meta) SetLastLogsize(value uint64) {
+	atomic.StoreUint64(&m.lastLogsize, value)
+}
+
+func (m *Meta) LastLogsize() uint64 {
+	return atomic.LoadUint64(&m.lastLogsize)
+}
+
+func (m *Meta) SetMtime(value int32) {
+	atomic.StoreInt32(&m.mtime, value)
+}
+
+func (m *Meta) Mtime() int32 {
+	return atomic.LoadInt32(&m.mtime)
+}
+
+type RegexpMatcher interface {
+	Match(value string, pattern string, mode int, output_template *string) (match bool, output string)
+}
+
+type ContextProvider interface {
+	ClientID() uint64
+	ItemID() uint64
+	Output() ResultWriter
+	Meta() *Meta
+	GlobalRegexp() RegexpMatcher
+}
+
+type Result struct {
+	Itemid uint64
+	Value  *string
+
+	// additional windows eventlog fields
+	EventSource    *string
+	EventID        *int
+	EventTimestamp *int
+	EventSeverity  *int
+
+	Ts          time.Time
+	Error       error
+	LastLogsize *uint64
+	Mtime       *int
+	Persistent  bool
+}
+
+type Request struct {
+	Itemid      uint64  `json:"itemid"`
+	Key         string  `json:"key"`
+	Delay       string  `json:"delay"`
+	LastLogsize *uint64 `json:"lastlogsize"`
+	Mtime       *int    `json:"mtime"`
+}
+
+// GlobalOptions are global agent configuration parameters that can be accessed by plugins.
+// In most cases it's recommended to allow plugins overriding global configuration parameters
+// they are using with plugin specific parameters.
+type GlobalOptions struct {
+	Timeout  int
+	SourceIP string
+}
+
+func init() {
+	UnsupportedMetricError = errors.New("Unsupported item key.")
+}

--- a/pkg/std/os.go
+++ b/pkg/std/os.go
@@ -1,0 +1,65 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+// package std is used to create wrappers for standard Go functions to support
+// mocking in tests where necessary
+package std
+
+import (
+	"io"
+	"os"
+)
+
+// File interface is used to mock os.File structure
+type File interface {
+	io.Reader
+	io.Closer
+}
+
+// Os interface is used to mock os package
+type Os interface {
+	Open(name string) (File, error)
+	Stat(name string) (os.FileInfo, error)
+	IsExist(err error) bool
+}
+
+// A FileMode represents a file's mode and permission bits.
+type FileMode uint32
+
+// wrappers for standard os functionality
+
+type sysOs struct {
+}
+
+func (o *sysOs) Open(name string) (File, error) {
+	return os.Open(name)
+}
+
+func (o *sysOs) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+func (o *sysOs) IsExist(err error) bool {
+	return os.IsExist(err)
+}
+
+// NewOs returns Os interface that forwards supported methods to os package.
+func NewOs() Os {
+	return &sysOs{}
+}

--- a/pkg/std/os_default.go
+++ b/pkg/std/os_default.go
@@ -1,0 +1,29 @@
+// +build !linux
+
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+// package std is used to create wrappers for standard Go functions to support
+// mocking in tests where necessary
+package std
+
+// NewMockOs returns Os interface that replaces supported os package functionality with mock functions.
+func NewMockOs() Os {
+	return &sysOs{}
+}

--- a/pkg/std/os_mock.go
+++ b/pkg/std/os_mock.go
@@ -1,0 +1,149 @@
+// +build linux
+
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+// package std is used to create wrappers for standard Go functions to support
+// mocking in tests where necessary
+package std
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// mocked os functionality
+
+type MockOs interface {
+	MockFile(path string, data []byte)
+}
+
+type fileTime struct {
+	ModTime time.Time
+}
+
+type mockOs struct {
+	files  map[string][]byte
+	ftimes map[string]fileTime
+}
+
+type mockFile struct {
+	buffer *bytes.Buffer
+}
+
+type fileStat struct {
+	name    string
+	size    int64
+	mode    FileMode
+	modTime time.Time
+	sys     syscall.Stat_t
+}
+
+func (o *mockOs) Open(name string) (File, error) {
+	if data, ok := o.files[name]; !ok {
+		return nil, errors.New("file does not exist")
+	} else {
+		return &mockFile{bytes.NewBuffer(data)}, nil
+	}
+}
+
+func (o *fileStat) IsDir() bool {
+	return false
+}
+
+func (o *fileStat) Mode() os.FileMode {
+	return os.FileMode(o.mode)
+}
+
+func (o *fileStat) ModTime() time.Time {
+	return o.modTime
+}
+
+func (o *fileStat) Name() string {
+	return o.name
+}
+
+func (o *fileStat) Size() int64 {
+	return o.size
+}
+
+func (o *fileStat) Sys() interface{} {
+	return &o.sys
+}
+
+func (o *mockOs) Stat(name string) (os.FileInfo, error) {
+	if data, ok := o.files[name]; !ok {
+		return nil, errors.New("file does not exist")
+	} else {
+		var fs fileStat
+
+		fs.mode = 436
+		fs.modTime = o.ftimes[name].ModTime
+		fs.name = name
+		fs.size = int64(len(data))
+		a, err := unix.TimeToTimespec(o.ftimes[name].ModTime)
+		if err != nil {
+			return nil, err
+		}
+		fs.sys.Atim.Sec = a.Sec
+		fs.sys.Ctim.Sec = a.Sec
+
+		return &fs, nil
+	}
+}
+
+func (o *mockOs) IsExist(err error) bool {
+
+	if err == nil {
+		return false
+	}
+	if err.Error() == "exists" {
+		return true
+	}
+	return false
+}
+
+func (f *mockFile) Close() error {
+	return nil
+}
+
+func (f *mockFile) Read(p []byte) (n int, err error) {
+	return f.buffer.Read(p)
+}
+
+// MockFile creates new mock file with the specified path and contents.
+func (o *mockOs) MockFile(path string, data []byte) {
+	o.files[path] = data
+	var ft fileTime
+	ft.ModTime = time.Now()
+	o.ftimes[path] = ft
+}
+
+// NewMockOs returns Os interface that replaces supported os package functionality with mock functions.
+func NewMockOs() Os {
+	return &mockOs{
+		files:  make(map[string][]byte),
+		ftimes: make(map[string]fileTime),
+	}
+}

--- a/pkg/uri/uri.go
+++ b/pkg/uri/uri.go
@@ -1,0 +1,237 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+// Package uri provides a helper for URI validation and parsing
+package uri
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type URI struct {
+	scheme   string
+	host     string
+	port     string
+	rawQuery string
+	socket   string
+	user     string
+	password string
+	rawUri   string
+}
+
+func (u *URI) Scheme() string {
+	return u.scheme
+}
+
+func (u *URI) Host() string {
+	return u.host
+}
+
+func (u *URI) Socket() string {
+	return u.socket
+}
+
+func (u *URI) Port() string {
+	return u.port
+}
+
+func (u *URI) GetParam(key string) string {
+	params, err := url.ParseQuery(u.rawQuery)
+	if err != nil {
+		return ""
+	}
+
+	return params.Get(key)
+}
+
+func (u *URI) Password() string {
+	return u.password
+}
+
+func (u *URI) User() string {
+	return u.user
+}
+
+// Addr combines a host and a port into a network address ("host:port") or returns a socket.
+func (u *URI) Addr() string {
+	if u.socket != "" {
+		return u.socket
+	}
+
+	if u.port == "" {
+		return u.host
+	}
+
+	return net.JoinHostPort(u.host, u.port)
+}
+
+// String reassembles the URI to a valid URI string.
+func (u *URI) String() string {
+	t := &url.URL{
+		Scheme:   u.scheme,
+		RawQuery: u.rawQuery,
+	}
+
+	if u.socket != "" {
+		t.Path = u.socket
+	} else {
+		if u.port == "" {
+			t.Host = u.host
+		} else {
+			t.Host = net.JoinHostPort(u.host, u.port)
+		}
+	}
+
+	if u.user != "" {
+		if u.password != "" {
+			t.User = url.UserPassword(u.user, u.password)
+		} else {
+			t.User = url.User(u.user)
+		}
+
+	}
+
+	return t.String()
+}
+
+func (u *URI) withCreds(user, password string) *URI {
+	u.password = password
+	u.user = user
+
+	return u
+}
+
+type Defaults struct {
+	Port   string
+	Scheme string
+}
+
+// New parses a given rawUri and returns a new filled URI structure.
+// It ignores embedded credentials according to https://www.ietf.org/rfc/rfc3986.txt.
+// Use NewWithCreds to add credentials to a structure.
+func New(rawUri string, defaults *Defaults) (res *URI, err error) {
+	var (
+		isSocket bool
+		noScheme bool
+		port     string
+	)
+
+	rawUri = strings.TrimSpace(rawUri)
+
+	res = &URI{
+		rawUri: rawUri,
+	}
+
+	// https://tools.ietf.org/html/rfc6874#section-2
+	// %25 is allowed to escape a percent sign in IPv6 scoped-address literals
+	if !strings.Contains(rawUri, "%25") {
+		rawUri = strings.Replace(rawUri, "%", "%25", -1)
+	}
+
+	if noScheme = !strings.Contains(rawUri, ":/"); noScheme {
+		if defaults != nil && defaults.Scheme != "" {
+			rawUri = defaults.Scheme + "://" + rawUri
+		} else {
+			rawUri = "tcp://" + rawUri
+		}
+	}
+
+	u, err := url.Parse(rawUri)
+	if err != nil {
+		return nil, err
+	}
+
+	res.scheme = u.Scheme
+	port = u.Port()
+
+	if port == "" {
+		if defaults != nil {
+			port = defaults.Port
+		}
+	}
+
+	if port != "" {
+		if _, err = strconv.ParseUint(port, 10, 16); err != nil {
+			return nil, errors.New("port must be integer and must be between 0 and 65535")
+		}
+	}
+
+	isSocket = res.scheme == "unix" || (noScheme && u.Hostname() == "" && u.Path != "")
+	if isSocket {
+		if u.Path == "" {
+			return nil, errors.New("socket is required")
+		}
+
+		res.scheme = "unix"
+		res.socket = u.Path
+	} else {
+		if u.Hostname() == "" {
+			return nil, errors.New("host is required")
+		}
+
+		res.host = u.Hostname()
+		res.port = port
+	}
+
+	res.rawQuery = u.RawQuery
+
+	return res, err
+}
+
+func NewWithCreds(rawUri, user, password string, defaults *Defaults) (res *URI, err error) {
+	res, err = New(rawUri, defaults)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.withCreds(user, password), nil
+}
+
+type URIValidator struct {
+	Defaults       *Defaults
+	AllowedSchemes []string
+}
+
+func (v URIValidator) Validate(value *string) error {
+	if value == nil {
+		return nil
+	}
+
+	res, err := New(*value, v.Defaults)
+	if err != nil {
+		return err
+	}
+
+	if v.AllowedSchemes != nil {
+		for _, s := range v.AllowedSchemes {
+			if res.Scheme() == s {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("allowed schemes: %s", strings.Join(v.AllowedSchemes, ", "))
+	}
+
+	return nil
+}

--- a/pkg/zbxerr/zbxerr.go
+++ b/pkg/zbxerr/zbxerr.go
@@ -1,0 +1,101 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+package zbxerr
+
+import (
+	"errors"
+	"unicode"
+)
+
+type ZabbixError struct {
+	err   error
+	cause error
+}
+
+// New creates a new ZabbixError
+func New(msg string) ZabbixError {
+	return ZabbixError{errors.New(msg), nil}
+}
+
+// Wrap creates a new ZabbixError with wrapped cause
+func (e ZabbixError) Wrap(cause error) error {
+	return ZabbixError{err: e, cause: cause}
+}
+
+// Unwrap extracts an original underlying error
+func (e ZabbixError) Unwrap() error {
+	return e.err
+}
+
+// Cause returns a cause of original error
+func (e ZabbixError) Cause() error {
+	return e.cause
+}
+
+// Error stringifies an error according to Zabbix requirements:
+// * the first letter must be capitalized;
+// * an error text should be trailed by a dot.
+func (e ZabbixError) Error() string {
+	var msg string
+
+	ucFirst := func(str string) string {
+		for i, v := range str {
+			return string(unicode.ToUpper(v)) + str[i+1:]
+		}
+
+		return ""
+	}
+
+	if zbxErr, ok := e.err.(ZabbixError); ok {
+		msg = zbxErr.Raw()
+	} else {
+		msg = e.err.Error()
+	}
+
+	if e.cause != nil {
+		msg += ": " + e.cause.Error()
+	}
+
+	if msg[len(msg)-1:] != "." {
+		msg += "."
+	}
+
+	return ucFirst(msg)
+}
+
+// Raw returns a non-modified error message
+func (e ZabbixError) Raw() string {
+	return e.err.Error()
+}
+
+var (
+	ErrorInvalidParams        = New("invalid parameters")
+	ErrorTooFewParameters     = New("too few parameters")
+	ErrorTooManyParameters    = New("too many parameters")
+	ErrorInvalidConfiguration = New("invalid configuration")
+	ErrorCannotFetchData      = New("cannot fetch data")
+	ErrorCannotUnmarshalJSON  = New("cannot unmarshal JSON")
+	ErrorCannotMarshalJSON    = New("cannot marshal JSON")
+	ErrorCannotParseResult    = New("cannot parse result")
+	ErrorConnectionFailed     = New("connection failed")
+	ErrorUnsupportedMetric    = New("unsupported metric")
+	ErrorEmptyResult          = New("empty result")
+	ErrorUnknownSession       = New("unknown session")
+)

--- a/plugins/web/certificate/certificate.go
+++ b/plugins/web/certificate/certificate.go
@@ -1,0 +1,247 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+package webcertificate
+
+import (
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"zabbix.com/pkg/conf"
+	"zabbix.com/pkg/plugin"
+	"zabbix.com/pkg/uri"
+	"zabbix.com/pkg/zbxerr"
+)
+
+type Output struct {
+	X509              Cert             `json:"x509"`
+	Result            ValidationResult `json:"result"`
+	Sha1Fingerprint   string           `json:"sha1_fingerprint"`
+	Sha256Fingerprint string           `json:"sha256_fingerprint"`
+}
+
+type CertTime struct {
+	Value     string `json:"value"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+type Cert struct {
+	Version            int      `json:"version"`
+	Serial             string   `json:"serial_number"`
+	SignatureAlgorithm string   `json:"signature_algorithm"`
+	Issuer             string   `json:"issuer"`
+	NotBefore          CertTime `json:"not_before"`
+	NotAfter           CertTime `json:"not_after"`
+	Subject            string   `json:"subject"`
+	PublicKeyAlgorithm string   `json:"public_key_algorithm"`
+	AlternativeNames   []string `json:"alternative_names"`
+}
+
+type ValidationResult struct {
+	Value   string `json:"value"`
+	Message string `json:"message"`
+}
+
+type Options struct {
+	Timeout int `conf:"optional,range=1:30"`
+}
+
+type Plugin struct {
+	plugin.Base
+	options Options
+}
+
+const (
+	dateFormat         = "Jan 02 15:04:05 2006 GMT"
+	allParameters      = 3
+	noThirdParameter   = 2
+	onlyFirstParameter = 1
+	emptyParameters    = 0
+)
+
+var impl Plugin
+
+func (p *Plugin) Configure(global *plugin.GlobalOptions, options interface{}) {
+	p.options.Timeout = global.Timeout
+}
+
+func (p *Plugin) Validate(options interface{}) error {
+	var o Options
+
+	return conf.Unmarshal(options, &o)
+}
+
+func (p *Plugin) Export(key string, params []string, ctx plugin.ContextProvider) (interface{}, error) {
+	if key != "web.certificate.get" {
+		return nil, plugin.UnsupportedMetricError
+	}
+
+	return p.webCertificateGet(params)
+}
+
+func (p *Plugin) webCertificateGet(params []string) (interface{}, error) {
+	hostname, port, domain, err := getParameters(params)
+	if err != nil {
+		return nil, zbxerr.ErrorInvalidParams.Wrap(err)
+	}
+
+	certs, err := getCertificatesPEM(fmt.Sprintf("%s:%s", hostname, port), domain, p.options.Timeout)
+	if err != nil {
+		return nil, zbxerr.ErrorCannotFetchData.Wrap(err)
+	}
+
+	if len(certs) < 1 {
+		return nil, zbxerr.ErrorCannotFetchData
+	}
+
+	leaf := certs[0]
+	leaf.KeyUsage = x509.KeyUsageCertSign
+
+	var o Output
+	o.X509 = Cert{
+		leaf.Version,
+		fmt.Sprintf("%x", leaf.SerialNumber.Bytes()),
+		leaf.SignatureAlgorithm.String(),
+		leaf.Issuer.ToRDNSequence().String(),
+		CertTime{leaf.NotBefore.UTC().Format(dateFormat), leaf.NotBefore.Unix()},
+		CertTime{leaf.NotAfter.UTC().Format(dateFormat), leaf.NotAfter.Unix()},
+		leaf.Subject.ToRDNSequence().String(),
+		leaf.PublicKeyAlgorithm.String(),
+		leaf.DNSNames,
+	}
+
+	o.Result = getValidationResult(
+		leaf, createVerificationOptions(domain, certs),
+		leaf.Subject.ToRDNSequence().String(), leaf.Issuer.ToRDNSequence().String(),
+	)
+
+	o.Sha1Fingerprint = fmt.Sprintf("%x", sha1.Sum(leaf.Raw))
+	o.Sha256Fingerprint = fmt.Sprintf("%x", sha256.Sum256(leaf.Raw))
+
+	b, err := json.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+
+	return string(b), nil
+}
+
+func createVerificationOptions(domain string, certs []*x509.Certificate) x509.VerifyOptions {
+	opts := x509.VerifyOptions{
+		DNSName:       domain,
+		Intermediates: x509.NewCertPool(),
+	}
+
+	for _, cert := range certs[1:] {
+		opts.Intermediates.AddCert(cert)
+	}
+
+	return opts
+}
+
+func getValidationResult(leaf *x509.Certificate, opts x509.VerifyOptions, subject, issuer string) ValidationResult {
+	var out ValidationResult
+
+	if _, err := leaf.Verify(opts); err != nil {
+		if errors.As(err, &x509.UnknownAuthorityError{}) && subject == issuer {
+			out = ValidationResult{
+				"valid-but-self-signed",
+				"certificate verified successfully, but determined to be self signed",
+			}
+		} else {
+			out = ValidationResult{"invalid", fmt.Sprintf("failed to verify certificate: %s", err.Error())}
+		}
+	} else {
+		out = ValidationResult{"valid", "certificate verified successfully"}
+	}
+
+	return out
+}
+
+func getParameters(params []string) (hostname, port, domain string, err error) {
+	switch len(params) {
+	case allParameters:
+		hostname, port, err = parseURL(params[0], params[1])
+		domain = hostname
+
+		if params[2] != "" {
+			hostname, port, err = parseURL(params[2], params[1])
+		}
+	case noThirdParameter:
+		hostname, port, err = parseURL(params[0], params[1])
+		domain = hostname
+	case onlyFirstParameter:
+		hostname, port, err = parseURL(params[0], "")
+		domain = hostname
+	case emptyParameters:
+		err = zbxerr.ErrorTooFewParameters
+	default:
+		err = zbxerr.ErrorTooManyParameters
+	}
+
+	return
+}
+
+func parseURL(url, port string) (string, string, error) {
+	uri, err := uri.New(url, &uri.Defaults{Port: port, Scheme: "https"})
+	if err != nil {
+		return "", "", err
+	}
+
+	if uri.Scheme() != "" && uri.Scheme() != "https" {
+		return "", "", errors.New("scheme must be https")
+	}
+
+	return getHostAndPort(uri, port)
+}
+
+func getHostAndPort(uri *uri.URI, port string) (string, string, error) {
+	if uri.Port() != "" && port != "" && uri.Port() != port {
+		return "", "", errors.New("port set incorrectly")
+	}
+
+	if uri.Port() == "" && port == "" {
+		return uri.Host(), "443", nil
+	}
+
+	return uri.Host(), uri.Port(), nil
+}
+
+func getCertificatesPEM(address, domain string, timeout int) ([]*x509.Certificate, error) {
+	var dialer net.Dialer
+	dialer.Timeout = time.Duration(timeout) * time.Second
+
+	conn, err := tls.DialWithDialer(&dialer, "tcp", address, &tls.Config{InsecureSkipVerify: true, ServerName: domain})
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	return conn.ConnectionState().PeerCertificates, nil
+}
+
+func init() {
+	plugin.RegisterMetrics(&impl, "WebCertificate", "web.certificate.get", "Get TLS/SSL website certificate.")
+}

--- a/src/sheepskin.c
+++ b/src/sheepskin.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/sheepskin.c
+++ b/src/sheepskin.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <curl/curl.h>
+#include <dlfcn.h>
 
 #include "module.h"
 
@@ -46,9 +46,34 @@ int	zbx_module_uninit(void)
 
 static int	sheep_web_certificate_get(AGENT_REQUEST *request, AGENT_RESULT *result)
 {
-	/* TODO */
-	SET_MSG_RESULT(result, strdup("Not implemented yet..."));
-	return SYSINFO_RET_FAIL;
+	static void	*lib = NULL;
+	static void	(*set_timeout)(int) = NULL;
+	static int	(*check_item)(AGENT_REQUEST *, AGENT_RESULT *) = NULL;
+
+	if (NULL == lib && NULL == (lib = dlopen("sheepskin-cgo.so", RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND)))
+	{
+		SET_MSG_RESULT(result, strdup(dlerror()));
+		return SYSINFO_RET_FAIL;
+	}
+
+	if (NULL == set_timeout)
+	{
+		if (NULL == (set_timeout = dlsym(lib, "sheep_set_timeout")))
+		{
+			SET_MSG_RESULT(result, strdup(dlerror()));
+			return SYSINFO_RET_FAIL;
+		}
+
+		set_timeout(sheep_item_timeout);
+	}
+
+	if (NULL == check_item && NULL == (check_item = dlsym(lib, "sheep_check_item")))
+	{
+		SET_MSG_RESULT(result, strdup(dlerror()));
+		return SYSINFO_RET_FAIL;
+	}
+
+	return check_item(request, result);
 }
 
 ZBX_METRIC	*zbx_module_item_list(void)

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,8 +7,10 @@ services:
       ZBX_DEBUGLEVEL: 4
       ZBX_LOADMODULE: sheepskin.so
       ZBX_PASSIVESERVERS: 127.0.0.1,::1
+      LD_LIBRARY_PATH: /var/lib/zabbix/modules/
     volumes:
     - ../sheepskin.so:/var/lib/zabbix/modules/sheepskin.so:ro
+    - ../sheepskin-cgo.so:/var/lib/zabbix/modules/sheepskin-cgo.so:ro
   agent2:
     image: zabbix/zabbix-agent2:alpine-trunk
     environment:


### PR DESCRIPTION
To achieve best compatibility with native Zabbix `web.certificate.get` item, module uses some of Zabbix Go code compiled into a shared library.
To work around [the issue of Go libraries and `fork()`](https://support.zabbix.com/browse/ZBX-10751), there is a C-only library that serves as a "façade" and registers module with Zabbix. It is also responsible for loading Go part of the implementation on the first invocation of `web.certificate.get`. At this point Zabbix has already performed `fork()` and everything works fine.