### PR TITLE
Use $ORIGIN to bundle two .so together and avoid LD_LIBRARY_PATH tricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ make
 ## install
 
 Copy `sheepskin.so` and `sheepskin-cgo.so` to a desired location, set up necessary permissions.
+Note that both have to be located in the same directory!
 
 ## configure
 
@@ -74,11 +75,7 @@ LoadModulePath=/path/to/modules/sheepskin.so
 Restart Zabbix agent / proxy / server.
 
 Note that you _don't need_ to mention `sheepskin-cgo.so` in Zabbix configuration file.
-It will be loaded in runtime using `dlopen("sheepskin-cgo.so", ...)`.
-
-Please make sure that
-[`dlopen()` can find](https://man7.org/linux/man-pages/man3/dlopen.3.html)
-`sheepskin-cgo.so` (e.g. by setting `LD_LIBRARY_PATH` appropriately).
+It will be loaded in runtime using [`dlopen()`](https://man7.org/linux/man-pages/man3/dlopen.3.html).
 
 ## use
 

--- a/src/sheepskin.c
+++ b/src/sheepskin.c
@@ -51,7 +51,7 @@ static int	sheep_web_certificate_get(AGENT_REQUEST *request, AGENT_RESULT *resul
 	static void	(*set_timeout)(int) = NULL;
 	static int	(*check_item)(AGENT_REQUEST *, AGENT_RESULT *) = NULL;
 
-	if (NULL == lib && NULL == (lib = dlopen("sheepskin-cgo.so", RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND)))
+	if (NULL == lib && NULL == (lib = dlopen("$ORIGIN/sheepskin-cgo.so", RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND)))
 	{
 		SET_MSG_RESULT(result, strdup(dlerror()));
 		return SYSINFO_RET_FAIL;

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       ZBX_DEBUGLEVEL: 4
       ZBX_LOADMODULE: sheepskin.so
       ZBX_PASSIVESERVERS: 127.0.0.1,::1
-      LD_LIBRARY_PATH: /var/lib/zabbix/modules/
     volumes:
     - ../sheepskin.so:/var/lib/zabbix/modules/sheepskin.so:ro
     - ../sheepskin-cgo.so:/var/lib/zabbix/modules/sheepskin-cgo.so:ro


### PR DESCRIPTION
[`man dl.so`](https://man7.org/linux/man-pages/man8/ld-linux.so.8.html):
> `$ORIGIN` expands to the directory containing the program or shared object.

So we just need to ensure that both `.so` files are located in the same directory and this will guarantee that `dlopen()` will be able to find `sheepskin-cgo.so`.